### PR TITLE
install_ovn.sh: Uncomment needed install of OVS

### DIFF
--- a/install_ovn.sh
+++ b/install_ovn.sh
@@ -21,7 +21,7 @@ cd /ovs;
 ./configure --localstatedir="/var" --sysconfdir="/etc" --prefix="/usr" \
 --enable-ssl
 make -j8;
-#make install
+make install
 cd /ovn
 
 # build and install


### PR DESCRIPTION
Uncomment make install line in script to ensure that image is
built with OVS binaries in the expected places.
